### PR TITLE
Add category filter dropdown to Navbar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -72,7 +72,26 @@
     color: #3498db;
   }
   
-  /* SECTIONS */
+  
+.nav-filter-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-right: 12px;
+}
+
+.category-filter-label {
+  font-weight: 600;
+}
+
+.category-filter-select {
+  border: 1px solid #9aa6b2;
+  border-radius: 4px;
+  padding: 4px 8px;
+  background-color: #fff;
+}
+
+/* SECTIONS */
   
   .headline {
     width: 100%;
@@ -219,6 +238,11 @@
     .navbar li {
       padding: 15px;
     }
+
+    .nav-filter-item {
+      justify-content: center;
+      margin-right: 0;
+    }
     
     .navbar li:first-child {
       margin-top: 50px;
@@ -237,7 +261,26 @@
     transform: translate(0%)!important;
   }
     
-    /* SECTIONS */
+    
+.nav-filter-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-right: 12px;
+}
+
+.category-filter-label {
+  font-weight: 600;
+}
+
+.category-filter-select {
+  border: 1px solid #9aa6b2;
+  border-radius: 4px;
+  padding: 4px 8px;
+  background-color: #fff;
+}
+
+/* SECTIONS */
     
     .headline {
       height: 20vh;

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders category filter', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const filterElement = screen.getByLabelText(/filter:/i);
+  expect(filterElement).toBeInTheDocument();
 });

--- a/src/Components/Navbar.js
+++ b/src/Components/Navbar.js
@@ -1,7 +1,28 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useHistory, useLocation } from 'react-router-dom';
+
+const categories = [
+  'general',
+  'business',
+  'entertainment',
+  'health',
+  'science',
+  'sports',
+  'technology',
+];
 
 const Navbar = () => {
+  const history = useHistory();
+  const location = useLocation();
+
+  const selectedCategory =
+    location.pathname === '/' ? 'general' : location.pathname.replace('/', '');
+
+  const handleCategoryChange = (event) => {
+    const selectedValue = event.target.value;
+    history.push(selectedValue === 'general' ? '/' : `/${selectedValue}`);
+  };
+
   return (
     <div>
       <div className="page-wrapper">
@@ -18,30 +39,30 @@ const Navbar = () => {
               <span className="bar"></span>
             </div>
             <ul className="nav no-search">
-              <li className="nav-item">
-                <Link to="/">Home</Link>
+              <li className="nav-item nav-filter-item">
+                <label htmlFor="category-filter" className="category-filter-label">
+                  Filter:
+                </label>
+                <select
+                  id="category-filter"
+                  className="category-filter-select"
+                  value={selectedCategory}
+                  onChange={handleCategoryChange}
+                >
+                  {categories.map((category) => (
+                    <option key={category} value={category}>
+                      {category.charAt(0).toUpperCase() + category.slice(1)}
+                    </option>
+                  ))}
+                </select>
               </li>
-              <li className="nav-item">
-                <Link to="/business">Business</Link>
-              </li>
-              <li className="nav-item">
-                <Link to="/entertainment">Entertainment</Link>
-              </li>
-              <li className="nav-item">
-                <Link to="/general">General</Link>
-              </li>
-              <li className="nav-item">
-                <Link to="/health">Health</Link>
-              </li>
-              <li className="nav-item">
-                <Link to="/science">Science</Link>
-              </li>
-              <li className="nav-item">
-                <Link to="/sports">Sports</Link>
-              </li>
-              <li className="nav-item">
-                <Link to="/technology">Technology</Link>
-              </li>
+              {categories.map((category) => (
+                <li key={category} className="nav-item">
+                  <Link to={category === 'general' ? '/' : `/${category}`}>
+                    {category.charAt(0).toUpperCase() + category.slice(1)}
+                  </Link>
+                </li>
+              ))}
             </ul>
           </nav>
         </div>


### PR DESCRIPTION
### Motivation
- Provide a quick way for users to switch news categories from the top navigation without navigating through links. 
- Keep navigation links and the filter UI in sync so category options are consistent. 
- Ensure the filter is usable on mobile by adjusting navigation layout and styles.

### Description
- Replaced the navbar implementation with a category-driven design that defines a shared `categories` array and renders both the nav links and a new `<select>` filter from that array in `src/Components/Navbar.js`.
- Wired the filter to routing using `useLocation` to reflect the active route and `useHistory` to navigate when the user changes the selection, using the select with `id="category-filter"` and `onChange` handler to push routes.
- Added styling rules in `src/App.css` for `.nav-filter-item`, `.category-filter-label`, and `.category-filter-select`, including mobile alignment adjustments to keep the filter usable in responsive layouts.
- Replaced the existing test in `src/App.test.js` to assert that the category filter renders by checking `screen.getByLabelText(/filter:/i)`.

### Testing
- Ran `npm test -- --watchAll=false` and the test suite passed (1 passed, 0 failed).
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d79989b108326b67dbae85d3a61e3)